### PR TITLE
add clear to reset data and display

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,7 @@ g.on("addline",function(e){
 });
 g.addTo(map);
 ```
+```javascript
+// reset data and display
+el.clear();
+```

--- a/spec/L.Control.Elevation.Spec.js
+++ b/spec/L.Control.Elevation.Spec.js
@@ -110,3 +110,34 @@ describe('L.Control.Elevation', function() {
 
 	});
 });
+
+describe('L.Control.Elevation', function() {
+	it('clears data to initial state', function() {
+		var el = new L.control.elevation();
+		var geojson = {
+			"name": "NewFeatureType",
+			"type": "FeatureCollection",
+			"features": [{
+					"type": "Feature",
+					"geometry": {
+						"type": "LineString",
+						"coordinates": [
+							[169.13693, -44.696476, 296],
+							[169.134602, -44.69764, 295],
+							[169.129983, -44.701164, 299]
+						]
+					},
+					"properties": null
+				}
+			]
+		};
+		var data = el._data;
+		var dist = el._dist;
+		var maxElevation = el._maxElevation;
+		el._addData(geojson);
+		el._clearData();
+		expect(el._data).toEqual(data);
+		expect(el._dist).toEqual(dist);
+		expect(el._maxElevation).toEqual(maxElevation);
+	});
+});

--- a/src/L.Control.Elevation.js
+++ b/src/L.Control.Elevation.js
@@ -440,6 +440,32 @@ L.Control.Elevation = L.Control.extend({
 			.attr("d", this._area);
 		this._updateAxis();
 		return;
+	},
+
+	/*
+	 * Reset data
+	 */
+	_clearData: function() {
+		this._data = null;
+		this._dist = null;
+		this._maxElevation = null;
+	},
+
+	/*
+	 * Reset data and display
+	 */
+	clear: function() {
+
+		this._clearData();
+
+		// workaround for 'Error: Problem parsing d=""' in Webkit when empty data
+		// https://groups.google.com/d/msg/d3-js/7rFxpXKXFhI/HzIO_NPeDuMJ
+		//this._areapath.datum(this._data).attr("d", this._area);
+		this._areapath.attr("d", "M0 0");
+
+		this._x.domain([0,1]);
+		this._y.domain([0,1]);
+		this._updateAxis();
 	}
 
 });


### PR DESCRIPTION
Adds new methods `clear` and `_clearData` that reset the data and the diagram. 

Use-case is to update the diagram when editing a route and to reset to initial state when the route is deleted.

There might be better ways to implement this, I'm not very familiar with d3.
