### PR TITLE
zoom via elevation & ability to add/remove control multiple times

### DIFF
--- a/src/L.Control.Elevation.js
+++ b/src/L.Control.Elevation.js
@@ -55,7 +55,7 @@ L.Control.Elevation = L.Control.extend({
             });
 
         var container = this._container = L.DomUtil.create("div", "elevation");
-        
+
         this._initToggle();
 
         var cont = d3.select(container);


### PR DESCRIPTION
Hi,

First, thank you for your elevation control.  It's very useful, I already use it in 3 maps.

Here are some minor fixes/enhancements:
1. onAdd() subtracts the margins from options.width and options.height.  If you remove the elevation control from the map, and add the same control again, it becomes smaller by the margins each time.  This is fixed by 5e26ef6.
2. Route data is cleared by onRemove(), making it impossible to add the control again without reloading the route file, which is "expensive".  The change in 5e5cfc1 lets us retain the data and still add/remove the control.  You may see this in action at http://adoroszlai.github.io/hellonagykovacsi-map/123.html where toggling full-screen also adds/removes the elevation plot.  Data can still be removed via clear().
3. clear() gives error if the control was not yet added to the map.  Added a simple check in bcbd677.
4. The new "zoom via elevation plot" feature is nice, but there is a minor bug: fitting only the selected start and end points can leave parts of the selected section out of view.  This can be reproduced by zooming in on the section between 25km and 52km in http://mrmufflon.github.io/Leaflet.Elevation/example/example.html  The fix for this bug is in d75be22.

Please let me know if you prefer any or all of the above in separate pull requests, or if you need me to make further tweaks to my changes -- I'm very new to GitHub.

thanks,
Attila
