### PR TITLE
make addData backwards compatible

### DIFF
--- a/src/L.Control.Elevation.js
+++ b/src/L.Control.Elevation.js
@@ -616,6 +616,9 @@ L.Control.Elevation = L.Control.extend({
         if (this._container) {
             this._applyData();
         }
+        if (layer == null) {
+            layer = d;
+        }
         layer.on("mousemove", this._handleLayerMouseOver.bind(this));
     },
 


### PR DESCRIPTION
Hi,

Please note that f5cdc14 is not backwards compatible.  Previously `addData` had only one parameter, so `layer` is undefined for direct callers.  Eg. `example/example_gpx.html` is broken.  The JSON example works fine, though.

To verify this fix, temporarily include `src/L.Control.Elevation.js` instead of `dist/Leaflet.Elevation-0.0.2.min.js` in `example/example_gpx.html`.

-Attila