### PR TITLE
Hide position indicator on layer 'mouseout'

### DIFF
--- a/src/L.Control.Elevation.js
+++ b/src/L.Control.Elevation.js
@@ -669,6 +669,7 @@ L.Control.Elevation = L.Control.extend({
         }
         if (layer) {
             layer.on("mousemove", this._handleLayerMouseOver.bind(this));
+            layer.on("mouseout", this._hidePositionMarker.bind(this));
         }
     },
 


### PR DESCRIPTION
The position indicator/marker on the diagram remains at last position after hovering over the data layer on the map. This adds a mouseout listener to the layer to remove the diagram indicator.