### PR TITLE
Add support for tracks which have points without altitude

### DIFF
--- a/src/L.Control.Elevation.js
+++ b/src/L.Control.Elevation.js
@@ -557,14 +557,17 @@ L.Control.Elevation = L.Control.extend({
                 var e = new L.LatLng(coords[i ? i - 1 : 0][1], coords[i ? i - 1 : 0][0]);
                 var newdist = opts.imperial ? s.distanceTo(e) * this.__mileFactor : s.distanceTo(e);
                 dist = dist + Math.round(newdist / 1000 * 100000) / 100000;
-                ele = ele < coords[i][2] ? coords[i][2] : ele;
-                data.push({
-                    dist: dist,
-                    altitude: opts.imperial ? coords[i][2] * this.__footFactor : coords[i][2],
-                    x: coords[i][0],
-                    y: coords[i][1],
-                    latlng: s
-                });
+                // skip point if it has not elevation
+                if (typeof coords[i][2] !== "undefined") {
+                  ele = ele < coords[i][2] ? coords[i][2] : ele;
+                  data.push({
+                      dist: dist,
+                      altitude: opts.imperial ? coords[i][2] * this.__footFactor : coords[i][2],
+                      x: coords[i][0],
+                      y: coords[i][1],
+                      latlng: s
+                  });
+                }
             }
             this._dist = dist;
             this._data = data;


### PR DESCRIPTION
Attached geojson, which has 2 points without altitude, is not correctly displayed with v0.0.4. The proposed patch just skips these points (still taking them into consideration in distance computation):
[ceyreste.zip](https://github.com/MrMufflon/Leaflet.Elevation/files/563854/ceyreste.zip)

