### PR TITLE
Zoom elevation plot

### DIFF
--- a/example/example.html
+++ b/example/example.html
@@ -18,7 +18,7 @@
 	<link rel="stylesheet" href="../dist/leaflet.elevation-0.0.4.css" />
 
 	<script type="text/javascript" src="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.js"></script>
-	<script type="text/javascript" src="../dist/leaflet.elevation-0.0.4.min.js"></script>
+	<script type="text/javascript" src="../src/L.Control.Elevation.js"></script>
 </head>
 <body>
 
@@ -27,7 +27,7 @@
 	<script type="text/javascript">
 		var map = new L.Map('map');
 
-		var url = 'http://otile{s}.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.jpeg',
+		var url = 'http://a.tile.openstreetmap.org/{z}/{x}/{y}.png',
 			attr ='Tiles Courtesy of <a href="http://www.mapquest.com/">MapQuest</a> &mdash; Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>',
 			service = new L.TileLayer(url, {subdomains:"1234",attribution: attr});
 

--- a/src/L.Control.Elevation.js
+++ b/src/L.Control.Elevation.js
@@ -99,7 +99,7 @@ L.Control.Elevation = L.Control.extend({
             .style("stroke", "none")
             .style("pointer-events", "all");
 
-	svg.append("clipPath").attr("id", "clip")
+	g.append("clipPath").attr("id", "clip")
 		.append("rect").attr("width", this._width())
 		.attr("height", this._height());
 
@@ -363,6 +363,11 @@ L.Control.Elevation = L.Control.extend({
      * @param j - this._data index of the end of zoom
      */
     _zoom: function(i,j) {
+        if (i > j) {
+            var tmp = j;
+	    j = i;
+	    i = tmp;
+	}
         var xdomain = d3.extent(this._data.slice(i,j), function(d) {
             return d.dist;
         });

--- a/src/L.Control.Elevation.js
+++ b/src/L.Control.Elevation.js
@@ -70,7 +70,7 @@ L.Control.Elevation = L.Control.extend({
 
         var cont = d3.select(container);
         cont.attr("width", opts.width);
-        var svg = cont.append("svg");
+        var svg = this._svg = cont.append("svg");
         svg.attr("width", opts.width)
             .attr("class", "background")
             .attr("height", opts.height)
@@ -199,6 +199,7 @@ L.Control.Elevation = L.Control.extend({
             this._hidePositionMarker();
 
             this._map.fitBounds(this._fullExtent);
+			this.animate(0, this._data.length-1);
 
         }
 
@@ -220,8 +221,10 @@ L.Control.Elevation = L.Control.extend({
 
         var item1 = this._findItemForX(this._dragStartCoords[0]),
             item2 = this._findItemForX(this._dragCurrentCoords[0]);
+		console.log(this._dragStartCoords[0] + " " + this._dragCurrentCoords[0]);
 
         this._fitSection(item1, item2);
+		this.animate( this._dragStartCoords[0], this._dragCurrentCoords[0] );
 
         this._dragStartCoords = null;
         this._gotDragged = false;
@@ -243,6 +246,7 @@ L.Control.Elevation = L.Control.extend({
      * Finds a data entry for a given x-coordinate of the diagram
      */
     _findItemForX: function(x) {
+		//console.log(x);
         var bisect = d3.bisector(function(d) {
             return d.dist;
         }).left;
@@ -338,6 +342,19 @@ L.Control.Elevation = L.Control.extend({
         var opts = this.options;
         return opts.height - opts.margins.top - opts.margins.bottom;
     },
+
+	animate: function(i,j) {
+		console.log( "animating" + i + " " + j);
+        var xdomain = d3.extent(this._data.slice(i,j), function(d) {
+            return d.dist;
+        });
+		this._x.domain(xdomain);
+		var t = this._svg.transition().duration(750);
+		//t.select("leaflet-control.elevation.axis").call
+		t.select(".area").attr("d", this._area);
+	},
+
+		
 
     /*
      * Fromatting funciton using the given decimals and seperator
@@ -559,6 +576,7 @@ L.Control.Elevation = L.Control.extend({
                 dist = dist + Math.round(newdist / 1000 * 100000) / 100000;
                 ele = ele < coords[i][2] ? coords[i][2] : ele;
                 data.push({
+					index: i,
                     dist: dist,
                     altitude: opts.imperial ? coords[i][2] * this.__footFactor : coords[i][2],
                     x: coords[i][0],
@@ -589,6 +607,7 @@ L.Control.Elevation = L.Control.extend({
                 dist = dist + Math.round(newdist / 1000 * 100000) / 100000;
                 ele = ele < s.meta.ele ? s.meta.ele : ele;
                 data.push({
+					index: i,
                     dist: dist,
                     altitude: opts.imperial ? s.meta.ele * this.__footFactor : s.meta.ele,
                     x: s.lng,

--- a/src/L.Control.Elevation.js
+++ b/src/L.Control.Elevation.js
@@ -27,7 +27,8 @@ L.Control.Elevation = L.Control.extend({
             iconCssClass: "elevation-toggle-icon",
             title: "Elevation"
         },
-        imperial: false
+        imperial: false,
+	elevationZoom: true
     },
     __mileFactor: 0.621371,
     __footFactor: 3.28084,
@@ -97,6 +98,10 @@ L.Control.Elevation = L.Control.extend({
             .style("fill", "none")
             .style("stroke", "none")
             .style("pointer-events", "all");
+
+	svg.append("clipPath").attr("id", "clip")
+		.append("rect").attr("width", this._width())
+		.attr("height", this._height());
 
         if (L.Browser.touch) {
 
@@ -199,7 +204,7 @@ L.Control.Elevation = L.Control.extend({
             this._hidePositionMarker();
         }
         this._map.fitBounds(this._fullExtent);
-        this.animate(0, this._data.length-1);
+        this._zoom(0, this._data.length-1);
 
     },
 
@@ -225,7 +230,7 @@ L.Control.Elevation = L.Control.extend({
 	}
 
         this._fitSection(item1, item2);
-        this.animate(item1, item2);
+        this._zoom(item1, item2);
 
         this._dragStartCoords = null;
         this._gotDragged = false;
@@ -349,7 +354,15 @@ L.Control.Elevation = L.Control.extend({
         return opts.height - opts.margins.top - opts.margins.bottom;
     },
 
-    animate: function(i,j) {
+    /*
+     * Zooms (in or out) the elevation graph
+     * for the given x item indexes
+     * (with awesome svg path animation)
+     *
+     * @param i - this._data index of the beggining of zoom
+     * @param j - this._data index of the end of zoom
+     */
+    _zoom: function(i,j) {
         var xdomain = d3.extent(this._data.slice(i,j), function(d) {
             return d.dist;
         });
@@ -767,7 +780,8 @@ L.Control.Elevation = L.Control.extend({
         this._x.domain(xdomain);
         this._y.domain(ydomain);
         this._areapath.datum(this._data)
-            .attr("d", this._area);
+            .attr("d", this._area)
+            .attr("clip-path", "url(#clip)");
         this._updateAxis();
 
         this._fullExtent = this._calculateFullExtent(this._data);


### PR DESCRIPTION
User can now zoom the particular part of the chart (svg path) with awesome animation.

Usage: _zoom(i,j), where i and j are range indexes of _data array. Currently, the _zoom is attached to the mouse drag events.

I created <clippath> element with inner rect. I'm not sure if this is not redundant, since there is already a rect in the svg.